### PR TITLE
Tighten permissions and use --fallback-x11 socket

### DIFF
--- a/org.cvfosammmm.Setzer.json
+++ b/org.cvfosammmm.Setzer.json
@@ -7,7 +7,6 @@
     "command": "setzer",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",

--- a/org.cvfosammmm.Setzer.json
+++ b/org.cvfosammmm.Setzer.json
@@ -10,7 +10,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
-        "--filesystem=host",
+        "--filesystem=xdg-documents",
         "--filesystem=xdg-run/dconf",
         "--filesystem=~/.config/dconf:ro",
         "--env=PATH=/app/bin:/usr/bin:/app/bin/x86_64-linux",


### PR DESCRIPTION
Setzer is a document editing program, sandbox should reflect that.

Also see flathub/flathub#1452