### PR TITLE
Update to GNOME 48

### DIFF
--- a/org.cvfosammmm.Setzer.json
+++ b/org.cvfosammmm.Setzer.json
@@ -1,7 +1,7 @@
 {
     "id": "org.cvfosammmm.Setzer",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.texlive"
@@ -11,7 +11,7 @@
             "directory": "texlive",
             "subdirectories": true,
             "autodelete": true,
-            "version": "23.08"
+            "version": "24.08"
         }
     },
     "command": "setzer",
@@ -48,7 +48,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.bz2",
+                    "url": "https://archives.boost.io/release/1.81.0/source/boost_1_81_0.tar.bz2",
                     "sha256": "71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa"
                 }
             ]
@@ -101,13 +101,16 @@
                 "*.h"
             ],
             "ensure-writable": [
-                "/lib/perl5/5.36.0"
+                "/lib/perl5/5.40.2"
+            ],
+            "post-install": [
+                "chmod -R u+w ${FLATPAK_DEST}/lib/perl5/5.40.2"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.cpan.org/src/5.0/perl-5.36.0.tar.gz",
-                    "sha256": "e26085af8ac396f62add8a533c3a0ea8c8497d836f0689347ac5abd7b7a4e00a"
+                    "url": "https://www.cpan.org/src/5.0/perl-5.40.2.tar.gz",
+                    "sha256": "10d4647cfbb543a7f9ae3e5f6851ec49305232ea7621aed24c7cfbb0bef4b70d"
                 },
                 {
                     "type": "script",
@@ -165,13 +168,20 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a0/41/8f53eff8e969dd8576ddfb45e7ed315407d27c7518ae49418be8ed532b07/numpy-1.25.2.tar.gz",
-                    "sha256": "fd608e19c8d7c55021dffd43bfe5492fab8cc105cc8986f813f8c3c048b38760",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "numpy"
-                   }
-               }
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed"
+                },
+                {
+                    "type": "file",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b"
+                }
             ],
             "cleanup": [
                 "/bin",


### PR DESCRIPTION
- Update boost URL (change of location)
- Update Perl (new runtime new version)
- Update numpy using binary wheels (fail to build)

Close #67 
Close #64
Close #51